### PR TITLE
fix: Jobs from a fork should use the right repo tag

### DIFF
--- a/src/github_sdk.py
+++ b/src/github_sdk.py
@@ -71,7 +71,7 @@ def send_envelope(trace):
 def get_extra_metadata(job):
     runs = get(job["run_url"]).json()
     workflow = get(runs["workflow_url"]).json()
-    repo = runs["head_repository"]["full_name"]
+    repo = runs["repository"]["full_name"]
     meta = {
         # "workflow_name": workflow["name"],
         "author": runs["head_commit"]["author"],


### PR DESCRIPTION
See [an example](https://api.github.com/repos/getsentry/sentry/actions/runs/2297579072):
<img width="296" alt="image" src="https://user-images.githubusercontent.com/44410/167705459-9add995d-b869-4688-8c2b-604fa360dc03.png">
