### PR TITLE
ref: Require initializing a client to use the code

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,6 @@
 import sys
 
-from github_sdk import get, send_trace
+from src.github_sdk import GithubClient
 
 # Point this script to the URL of a job and we will trace it
 # You give us this https://github.com/getsentry/sentry/runs/5759197422?check_suite_focus=true
@@ -8,17 +8,18 @@ from github_sdk import get, send_trace
 # e.g. tests/fixtures/jobA/job.json
 if __name__ == "__main__":
     argument = sys.argv[1]
+    client = GithubClient()
     if argument.startswith("https"):
         _, _, _, org, repo, _, run_id = argument.split("?")[0].split("/")
         url = f"https://api.github.com/repos/{org}/{repo}/actions/jobs/{run_id}"
-        req = get(url)
+        req = client._fetch_github(url)
         if not req.ok:
             raise Exception(req.text)
-        send_trace(req.json())
+        client.send_trace(req.json())
     else:
         import json
 
         data = {}
         with open(argument) as f:
             data = json.load(f)
-        send_trace(data)
+        client.send_trace(data)

--- a/src/github_sdk.py
+++ b/src/github_sdk.py
@@ -1,7 +1,6 @@
 import gzip
 import io
 import logging
-import os
 import uuid
 from datetime import datetime
 
@@ -9,93 +8,127 @@ import requests
 from sentry_sdk.envelope import Envelope
 from sentry_sdk.utils import format_timestamp
 
-logging.basicConfig(level=os.environ.get("LOGGING_LEVEL", "INFO"))
-
-# We need an authorized token to fetch the API. If you have SSO on your org you will need to grant permission
-# Your app and the Github webhook will share this secret
-# You can create an .env file and place the token in it
-GH_TOKEN = os.environ.get("GH_TOKEN")
-# Where to report Github actions transactions
-SENTRY_GITHUB_DSN = os.environ.get("SENTRY_GITHUB_DSN")
-
 
 class GithubSentryError(Exception):
     pass
 
 
-def get(url):
-    headers = {}
-    if GH_TOKEN and url.find("github.com") >= 0:
-        headers["Authorization"] = f"token {GH_TOKEN}"
-    req = requests.get(url, headers=headers)
-    if not req.ok:
-        raise Exception(req.text)
-    return req
+class GithubClient:
+    # This transform GH jobs conclusion keywords to Sentry performance status
+    github_status_trace_status = {"success": "ok", "failure": "internal_error"}
+
+    def __init__(self, dsn=None, github_token=None, dry_run=False) -> None:
+        self.token = github_token
+
+        if not dsn and not dry_run:
+            raise GithubSentryError("Set SENTRY_GITHUB_SDN in order to send envelopes.")
+
+        if dsn:
+            base_uri, project_id = dsn.rsplit("/", 1)
+            self.sentry_key = base_uri.rsplit("@")[0].rsplit("https://")[1]
+            # '{BASE_URI}/api/{PROJECT_ID}/{ENDPOINT}/'
+            self.sentry_project_url = f"{base_uri}/api/{project_id}/envelope/"
+
+    def send_trace(self, job):
+        # This can happen when the workflow is skipped and there are no steps
+        if job["conclusion"] == "skipped":
+            logging.info(
+                f"We are ignoring '{job['name']}' because it was skipped -> {job['html_url']}"
+            )
+            return
+        trace = self._generate_trace(job)
+        if trace:
+            return self._send_envelope(trace)
+
+    def _fetch_github(self, url):
+        headers = {}
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        req = requests.get(url, headers=headers)
+        req.raise_for_status()
+        return req
+
+    def _get_extra_metadata(self, job):
+        # XXX: This is the slowest call
+        runs = self._fetch_github(job["run_url"]).json()
+        workflow = self._fetch_github(runs["workflow_url"]).json()
+        repo = runs["repository"]["full_name"]
+        meta = {
+            # "workflow_name": workflow["name"],
+            "author": runs["head_commit"]["author"],
+            # https://getsentry.atlassian.net/browse/TET-22
+            # Tags are not linkified externally, plain text data can be selected in browsers and opened
+            "data": {
+                "job": job["html_url"],
+            },
+            "tags": {
+                "job_status": job["conclusion"],  # e.g. success, failure, skipped
+                "branch": runs["head_branch"],
+                "commit": runs["head_sha"],
+                "repo": repo,
+                "run_attempt": runs["run_attempt"],  # Rerunning a job
+                # It allows querying jobs within the same workflow (e.g. foo.yml)
+                "workflow": workflow["path"].rsplit("/")[-1],
+            },
+        }
+        if runs.get("pull_requests"):
+            pr_number = runs["pull_requests"][0]["number"]
+            meta["data"]["pr"] = f"https://github.com/{repo}/pull/{pr_number}"
+            meta["tags"]["pull_request"] = pr_number
+
+        return meta
+
+    # Documentation about traces, transactions and spans
+    # https://docs.sentry.io/product/sentry-basics/tracing/distributed-tracing/#traces
+    # https://develop.sentry.dev/sdk/performance/
+    def _generate_trace(self, job):
+        meta = self._get_extra_metadata(job)
+        transaction = _base_transaction(job)
+        transaction["user"] = meta["author"]
+        transaction["tags"] = meta["tags"]
+        transaction["contexts"]["trace"]["data"] = meta["data"]
+
+        # Transactions have name, spans don't.
+        transaction["contexts"]["trace"]["op"] = job["name"]
+        transaction["contexts"]["trace"]["description"] = job["name"]
+        transaction["contexts"]["trace"][
+            "status"
+        ] = self.github_status_trace_status.get(job["conclusion"], "unimplemented")
+        transaction["spans"] = _generate_spans(
+            job["steps"],
+            transaction["contexts"]["trace"]["span_id"],
+            transaction["contexts"]["trace"]["trace_id"],
+        )
+        return transaction
+
+    def _send_envelope(self, trace):
+        envelope = Envelope()
+        envelope.add_transaction(trace)
+        now = datetime.utcnow()
+
+        headers = {
+            "event_id": get_uuid(),  # Does this have to match anything?
+            "sent_at": format_timestamp(now),
+            "Content-Type": "application/x-sentry-envelope",
+            "Content-Encoding": "gzip",
+            "X-Sentry-Auth": f"Sentry sentry_key={self.sentry_key},"
+            + f"sentry_client=gha-sentry/0.0.1,sentry_timestamp={now},"
+            + "sentry_version=7",
+        }
+
+        body = io.BytesIO()
+        with gzip.GzipFile(fileobj=body, mode="w") as f:
+            envelope.serialize_into(f)
+
+        req = requests.post(
+            self.sentry_project_url, data=body.getvalue(), headers=headers
+        )
+        req.raise_for_status()
+        return req
 
 
 def get_uuid():
     return uuid.uuid4().hex
-
-
-def send_envelope(trace):
-    if not SENTRY_GITHUB_DSN:
-        raise GithubSentryError("Set SENTRY_GITHUB_SDN in order to send envelopes.")
-    envelope = Envelope()
-    envelope.add_transaction(trace)
-    base_uri, project_id = SENTRY_GITHUB_DSN.rsplit("/", 1)
-    sentry_key = base_uri.rsplit("@")[0].rsplit("https://")[1]
-    headers = {
-        "event_id": get_uuid(),  # Does this have to match anything?
-        "sent_at": format_timestamp(datetime.utcnow()),
-        "Content-Type": "application/x-sentry-envelope",
-        "Content-Encoding": "gzip",
-        "X-Sentry-Auth": f"Sentry sentry_key={sentry_key},"
-        + f"sentry_client=gha-sentry/0.0.1,sentry_timestamp={str(datetime.utcnow())},"
-        + "sentry_version=7",
-    }
-
-    # '{BASE_URI}/api/{PROJECT_ID}/{ENDPOINT}/'
-    url = f"{base_uri}/api/{project_id}/envelope/"
-    if GH_TOKEN and url.find("github.com") >= 0:
-        headers["Authorization"] = f"token {GH_TOKEN}"
-
-    body = io.BytesIO()
-    with gzip.GzipFile(fileobj=body, mode="w") as f:
-        envelope.serialize_into(f)
-
-    req = requests.post(url, data=body.getvalue(), headers=headers)
-    req.raise_for_status()
-
-
-# XXX: This is a slow call
-def get_extra_metadata(job):
-    runs = get(job["run_url"]).json()
-    workflow = get(runs["workflow_url"]).json()
-    repo = runs["repository"]["full_name"]
-    meta = {
-        # "workflow_name": workflow["name"],
-        "author": runs["head_commit"]["author"],
-        # https://getsentry.atlassian.net/browse/TET-22
-        # Tags are not linkified externally, plain text data can be selected in browsers and opened
-        "data": {
-            "job": job["html_url"],
-        },
-        "tags": {
-            "job_status": job["conclusion"],  # e.g. success, failure, skipped
-            "branch": runs["head_branch"],
-            "commit": runs["head_sha"],
-            "repo": repo,
-            "run_attempt": runs["run_attempt"],  # Rerunning a job
-            # It allows querying jobs within the same workflow (e.g. foo.yml)
-            "workflow": workflow["path"].rsplit("/")[-1],
-        },
-    }
-    if runs.get("pull_requests"):
-        pr_number = runs["pull_requests"][0]["number"]
-        meta["data"]["pr"] = f"https://github.com/{repo}/pull/{pr_number}"
-        meta["tags"]["pull_request"] = pr_number
-
-    return meta
 
 
 def _base_transaction(job):
@@ -138,40 +171,3 @@ def _generate_spans(steps, parent_span_id, trace_id):
         except Exception as e:
             logging.exception(e)
     return spans
-
-
-github_status_trace_status = {"success": "ok", "failure": "internal_error"}
-# Documentation about traces, transactions and spans
-# https://docs.sentry.io/product/sentry-basics/tracing/distributed-tracing/#traces
-# https://develop.sentry.dev/sdk/performance/
-def _generate_trace(job):
-    meta = get_extra_metadata(job)
-    transaction = _base_transaction(job)
-    transaction["user"] = meta["author"]
-    transaction["tags"] = meta["tags"]
-    transaction["contexts"]["trace"]["data"] = meta["data"]
-
-    # Transactions have name, spans don't.
-    transaction["contexts"]["trace"]["op"] = job["name"]
-    transaction["contexts"]["trace"]["description"] = job["name"]
-    transaction["contexts"]["trace"]["status"] = github_status_trace_status.get(
-        job["conclusion"], "unimplemented"
-    )
-    transaction["spans"] = _generate_spans(
-        job["steps"],
-        transaction["contexts"]["trace"]["span_id"],
-        transaction["contexts"]["trace"]["trace_id"],
-    )
-    return transaction
-
-
-def send_trace(workflow):
-    # This can happen when the workflow is skipped and there are no steps
-    if workflow["conclusion"] == "skipped":
-        logging.info(
-            f"We are ignoring '{workflow['name']}' because it was skipped -> {workflow['html_url']}"
-        )
-        return
-    trace = _generate_trace(workflow)
-    if trace:
-        send_envelope(trace)

--- a/src/github_sdk.py
+++ b/src/github_sdk.py
@@ -34,17 +34,6 @@ class GithubClient:
             # '{BASE_URI}/api/{PROJECT_ID}/{ENDPOINT}/'
             self.sentry_project_url = f"{base_uri}/api/{project_id}/envelope/"
 
-    def send_trace(self, job):
-        # This can happen when the workflow is skipped and there are no steps
-        if job["conclusion"] == "skipped":
-            logging.info(
-                f"We are ignoring '{job['name']}' because it was skipped -> {job['html_url']}"
-            )
-            return
-        trace = self._generate_trace(job)
-        if trace:
-            return self._send_envelope(trace)
-
     def _fetch_github(self, url):
         headers = {}
         if self.token:
@@ -130,6 +119,17 @@ class GithubClient:
         )
         req.raise_for_status()
         return req
+
+    def send_trace(self, job):
+        # This can happen when the workflow is skipped and there are no steps
+        if job["conclusion"] == "skipped":
+            logging.info(
+                f"We are ignoring '{job['name']}' because it was skipped -> {job['html_url']}"
+            )
+            return
+        trace = self._generate_trace(job)
+        if trace:
+            return self._send_envelope(trace)
 
 
 def _base_transaction(job):

--- a/src/github_sdk.py
+++ b/src/github_sdk.py
@@ -13,6 +13,10 @@ class GithubSentryError(Exception):
     pass
 
 
+def get_uuid():
+    return uuid.uuid4().hex
+
+
 class GithubClient:
     # This transform GH jobs conclusion keywords to Sentry performance status
     github_status_trace_status = {"success": "ok", "failure": "internal_error"}
@@ -20,6 +24,7 @@ class GithubClient:
     def __init__(self, dsn=None, github_token=None, dry_run=False) -> None:
         self.token = github_token
 
+        # XXX: Make dsn mandatory in the future
         if not dsn and not dry_run:
             raise GithubSentryError("Set SENTRY_GITHUB_SDN in order to send envelopes.")
 
@@ -125,10 +130,6 @@ class GithubClient:
         )
         req.raise_for_status()
         return req
-
-
-def get_uuid():
-    return uuid.uuid4().hex
 
 
 def _base_transaction(job):

--- a/src/github_sdk.py
+++ b/src/github_sdk.py
@@ -21,13 +21,8 @@ class GithubClient:
     # This transform GH jobs conclusion keywords to Sentry performance status
     github_status_trace_status = {"success": "ok", "failure": "internal_error"}
 
-    def __init__(self, dsn=None, github_token=None, dry_run=False) -> None:
+    def __init__(self, dsn, github_token=None) -> None:
         self.token = github_token
-
-        # XXX: Make dsn mandatory in the future
-        if not dsn and not dry_run:
-            raise GithubSentryError("Set SENTRY_GITHUB_SDN in order to send envelopes.")
-
         if dsn:
             base_uri, project_id = dsn.rsplit("/", 1)
             self.sentry_key = base_uri.rsplit("@")[0].rsplit("https://")[1]

--- a/src/handle_event.py
+++ b/src/handle_event.py
@@ -1,5 +1,13 @@
-from .github_sdk import send_trace
+from http import client
+import os
+from .github_sdk import GithubClient
 
+# We need an authorized token to fetch the API. If you have SSO on your org you will need to grant permission
+# Your app and the Github webhook will share this secret
+# You can create an .env file and place the token in it
+GH_TOKEN = os.environ.get("GH_TOKEN")
+# Where to report Github actions transactions
+SENTRY_GITHUB_DSN = os.environ.get("SENTRY_GITHUB_DSN")
 
 # XXX: Create a new function that does the try/finally of the main() function?
 def handle_event(data, headers):
@@ -12,6 +20,9 @@ def handle_event(data, headers):
     elif data["action"] != "completed":
         reason = "We cannot do anything with this workflow state."
     else:
-        send_trace(data["workflow_job"])
+        client = GithubClient(
+            dsn=SENTRY_GITHUB_DSN,
+        )
+        client.send_trace(data["workflow_job"])
 
     return reason, http_code

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -43,4 +43,5 @@ def uuid_list():
         "a7776ed12daa449bb0642e9ea1bb4152",
         "6e147ff372f9498abb5749a1210d8e0a",
         "498cceede5f14fd991778f007b237803",
+        "a401d83c7ec0495f82a8da8d9a389f5b",
     ]

--- a/tests/test_github_sdk.py
+++ b/tests/test_github_sdk.py
@@ -1,27 +1,34 @@
+from datetime import datetime
 from unittest.mock import patch
 
 import responses
 from freezegun import freeze_time
 
-from src.github_sdk import GithubSentryError, send_envelope, send_trace, _generate_trace
+from src.github_sdk import GithubSentryError, GithubClient
 from .fixtures import *
 
 
 @responses.activate
 def test_job_without_steps(skipped_workflow):
-    assert send_trace(skipped_workflow) == None
+    sdk = GithubClient(dry_run=True)
+    assert sdk.send_trace(skipped_workflow) == None
 
 
-def test_send_trace_without_setting_dsn(jobA_trace):
+def test_initialize_without_setting_dsn():
     with pytest.raises(GithubSentryError):
-        assert send_envelope(jobA_trace)
+        GithubClient()
 
 
 @freeze_time()
 @responses.activate
 @patch("src.github_sdk.get_uuid")
-def test_job_basic_test(
-    mock_get_uuid, jobA_job, jobA_runs, jobA_workflow, jobA_trace, uuid_list
+def test_trace_generation(
+    mock_get_uuid,
+    jobA_job,
+    jobA_runs,
+    jobA_workflow,
+    jobA_trace,
+    uuid_list,
 ):
     mock_get_uuid.side_effect = uuid_list
     responses.get(
@@ -32,4 +39,59 @@ def test_job_basic_test(
         "https://api.github.com/repos/getsentry/sentry/actions/workflows/1174556",
         json=jobA_workflow,
     )
-    assert _generate_trace(jobA_job) == jobA_trace
+    client = GithubClient(dry_run=True)
+    assert client._generate_trace(jobA_job) == jobA_trace
+
+
+@freeze_time()
+@responses.activate
+@patch("src.github_sdk.get_uuid")
+def test_send_trace(
+    mock_get_uuid,
+    jobA_job,
+    jobA_runs,
+    jobA_workflow,
+    jobA_trace,
+    uuid_list,
+):
+    mock_get_uuid.side_effect = uuid_list
+    responses.get(
+        "https://api.github.com/repos/getsentry/sentry/actions/runs/2104746951",
+        json=jobA_runs,
+    )
+    responses.get(
+        "https://api.github.com/repos/getsentry/sentry/actions/workflows/1174556",
+        json=jobA_workflow,
+    )
+    dsn_url = "https://foo@random.ingest.sentry.io"
+    responses.post(
+        f"{dsn_url}/api/bar/envelope/",
+        json={"type": "post"},
+    )
+
+    client = GithubClient(dsn=f"{dsn_url}/bar")
+    resp = client.send_trace(jobA_job)
+    # This cannot happen in a fixture, otherwise, there will be a tiny bit of a clock drift
+    now = datetime.utcnow()
+
+    envelope_headers = {
+        "User-Agent": "python-requests/2.27.1",
+        "Accept-Encoding": "gzip, deflate",
+        "Accept": "*/*",
+        "Connection": "keep-alive",
+        "event_id": "a401d83c7ec0495f82a8da8d9a389f5b",
+        "sent_at": format_timestamp(now),
+        "Content-Type": "application/x-sentry-envelope",
+        "Content-Encoding": "gzip",
+        "X-Sentry-Auth": f"Sentry sentry_key=foo,sentry_client=gha-sentry/0.0.1,sentry_timestamp={now},sentry_version=7",
+        "Content-Length": "701",
+    }
+
+    for k, v in resp.request.headers.items():
+        assert envelope_headers[k] == v
+
+    # XXX: We will deal with this another time
+    # assert (
+    #     resp.request.body
+    #     == b"\x1f\x8b\x08\x00\xf1\x16}b\x02\xff\xb5TM\x8f\xd30\x10\xbd\xef\xaf\x88|\x02\xa9m\x1c\xc7\x89\x93H\x08\xd0\x8a;\x12\x9c@\xa8\x9a\xd8\xe3&\xbb\xf9\"vX\xaa\xaa\xff\x1d{\xdb\xee\x97\x96n\xcb\x8aS\xd3\x99\xf1\xf8\xbd7o\xbc\xd9^l\x88]\x0fH\nbG\xe8\x0cH[\xf7\x1d\x99\x11\xd9w\x16;\xbb\xdc'a\x18\x9aZ\x82O\x86W\xe6\xb6\xa2\xc1ne+RD\x19\xa7\xbe\r\xfe\xf2\xf5\xb5r\xd5\t \x139H\x95g\x8c\xcbRC\x96P\xceh\x14K]\xea\xac\x14\xee\xf4\xb3\x97>\xfcW\x10=\xdebP\x81EcM\xf0\x86\xbe=\xe0\xfam\r)6\xbe\\\xa2\xff0\x03t\xbb\x9b\x81\xd3He\xb1\x14()\xcf\x13\xbdk*q\x97\xcd\xa2\x92\x96\x08)\xa0\xd2<\x8b\x04\x08\xaeb\xa6\x04Ms\x9a)\xcd\x1e\xe1r\xadgD\x81\x05\x7f\xc3U_\xbahe\xed`\x8a0\\\xd5\xb6\x9a\xca\x85\xec\xdbp\x85\xd68\xde\xe3:\xdc\xff\x8cSg\xc2$KD\xc2\x04O\xe8{Y\xa1\xbc^\x9a\xa9\xb6\xb8\xd4\xbd\x9c\xcc;;N\xbe\xf50\x9e\xd8q\x98\x9a&\x8c\xe3\x98\x0b\xb2\x9d\x91~\xf8\x9b4\n\x8d\x1c\xeb\xe1\x98z\xc6\x82\x9d\x9cv\xa4\xbf&[\xd7l28zz\x1d\xb4\x9e\xf5\xc7\xaaE\x15|\xb2\xa8\xd7\xae\x18[\xa8\x1b\xaf\xa9\x8f.\xd0G#\xf6a\xe5\xa3\x1e\xa8\x07\xe3\xfa\x8d\xce#u\xeb\xee\x80\xd6#c\x94\xb19\xe5s\x9a~\x8d\xf2\"aE$\xbeyY\x9f/a\xb4\xa0I\x11\xefJ`e\xf6R/\xefp\x9aIJ4\xc6\xa5K\xe7\rY\x1d\xe0\x84\xa0\xd4\xdc\xa1\xae\xbb\xd5\xbc\x81\xb5c\xe1\xad\xd1\xb6\xb5\xf5\xd4U.R\x16e\x90s\x95\x01\x95\x8aQ\xe7\x88(B\x10\xaa\xc44\x93\x89\x88Qs\xe5\xce\x8c8\xf4\xee\xc4S\xcd}f\xea\x96`-\xb6\x83k\x19\xcd\xc8M?^\xeb\xa6\xbf\xf1\x08\x1c\xa6\xc1:8\xb8X\xb7\x8d\x1f\xa5\x9b\xd0r\xc4\x9f\x93\xe3H\x8a\xdbQyq\x9c+\x1d\x87\xef\x9b\xdd\xcc\xbe\xa0\r\xa6!\xf0N\x9a\x1d\x04\x7f\x14\x1b`\xf4\x1bt\xd4\xcc\xf7I*X\xaaK\x0e,\xe6\x11\x17B\x92\xd3\xa6\x91.(\xa5G&\xb2+c\xf4\xae\xec\x8c\xed\xd9\xce\xf6T?;=\x82U%\xc7E\xdd?\xf0\xf3n\xb3\xe7\x95m\x9b\xb9\xed\xe7u\x0b+,\x1a\xf0\x06\xbd\x97\xe4\x9f\xce\x9e'\x1d\x08!RT\x11S\x00\x9c\xe7\xe5i\xd2=\xd0\xe4XY\x92\xbdN\xba\xde\xd8\xe0\xd2\xbf\x19\xfdd\x83;7\x1e\xc4y>{\x1e\xfd\x14\x9da\xb4\x8e\x05\xd39\xcf3x\x89\xfeaI_\xa0\xbf/K^E\xff\xb2o\x87\xc6=5\x8f\xd7\xe4I\xf4<\xba\x8e\xa2\xdbWT\x98\xe8\x88\xbb\xa7\xe1D\xba\xc9\xff\xa4\xfbc{\xf1\x07Hk>,{\x07\x00\x00"
+    # )

--- a/tests/test_github_sdk.py
+++ b/tests/test_github_sdk.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 from unittest.mock import patch
 
+import requests
 import responses
 from freezegun import freeze_time
 from sentry_sdk.utils import format_timestamp
 
-from src.github_sdk import GithubSentryError, GithubClient
+from src.github_sdk import GithubClient
 from .fixtures import *
 
 dsn_url = "https://foo@random.ingest.sentry.io/bar"
@@ -73,7 +74,7 @@ def test_send_trace(
     now = datetime.utcnow()
 
     envelope_headers = {
-        "User-Agent": "python-requests/2.25.1",
+        "User-Agent": f"python-requests/{requests.__version__}",
         "Accept-Encoding": "gzip, deflate",
         "Accept": "*/*",
         "Connection": "keep-alive",

--- a/tests/test_handle_event.py
+++ b/tests/test_handle_event.py
@@ -1,5 +1,10 @@
+import os
+
 import pytest
 from src.handle_event import handle_event
+
+# XXX: Fix this
+os.environ["SENTRY_GITHUB_DSN"] = "https://foo@random.ingest.sentry.io/bar"
 
 
 def test_invalid_header():


### PR DESCRIPTION
The `github_sdk` module should not read environment variables but rather requiring it to be configuring explicitly.

This will enable further configurations in the future like defining what types of events should be processed rather than hard-coding it.

This also increases the code coverage by calling `send_trace`.

<img width="545" alt="image" src="https://user-images.githubusercontent.com/44410/168106769-8fe5cce5-b5e3-4bea-a21e-9c41e061e31b.png">
