### PR TITLE
feat: Add a new tag indicating which step a workflow failed at

### DIFF
--- a/src/github_sdk.py
+++ b/src/github_sdk.py
@@ -74,6 +74,12 @@ class GithubClient:
             pr_number = runs["pull_requests"][0]["number"]
             meta["data"]["pr"] = f"https://github.com/{repo}/pull/{pr_number}"
             meta["tags"]["pull_request"] = pr_number
+        if job["conclusion"] == "failure":
+            failing_steps = [
+                step for step in job["steps"] if step["conclusion"] == "failure"
+            ]
+            if len(failing_steps) > 0:
+                meta["tags"]["failing_step"] = failing_steps[0]["name"]
 
         return meta
 


### PR DESCRIPTION
## Motivation

It would be useful to see which stages a pipeline fails at most often, in order to better assess its overall health.

## Idea

By adding a tag that indicates the step at which a workflow fails, we can split charts by stage in Sentry. For example, one could filter by repo and then group results by failure step.

## Implementation

According to the [workflow job API documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_job), `conclusion` and `steps` are required keys in the job payload, so the key accesses should never fail. Additionally, this change introduces no new behavior for pipelines that complete without error.