### PR TITLE
feat(github): Add event tag to Sentry payload

### DIFF
--- a/src/github_sdk.py
+++ b/src/github_sdk.py
@@ -66,6 +66,7 @@ class GithubClient:
                 "commit": runs["head_sha"],
                 "repo": repo,
                 "run_attempt": runs["run_attempt"],  # Rerunning a job
+                "event": runs["event"],
                 # It allows querying jobs within the same workflow (e.g. foo.yml)
                 "workflow": workflow["path"].rsplit("/")[-1],
             },

--- a/tests/fixtures/jobA/trace.json
+++ b/tests/fixtures/jobA/trace.json
@@ -59,6 +59,7 @@
     "job_status": "success",
     "pull_request": 33347,
     "repo": "getsentry/sentry",
+    "event": "pull_request",
     "run_attempt": 1,
     "workflow": "acceptance.yml"
   },

--- a/tests/test_github_sdk.py
+++ b/tests/test_github_sdk.py
@@ -107,6 +107,7 @@ def test_trace_generation_with_failing_steps(
 
     # make sure the failing step exists
     assert trace["tags"]["failing_step"] == "Run calculate tests"
+    assert trace["tags"]["event"] == "push"
 
 
 @freeze_time()
@@ -146,7 +147,7 @@ def test_send_trace(
         "Content-Type": "application/x-sentry-envelope",
         "Content-Encoding": "gzip",
         "X-Sentry-Auth": f"Sentry sentry_key=foo,sentry_client=gha-sentry/0.0.1,sentry_timestamp={now},sentry_version=7",
-        "Content-Length": "693",
+        "Content-Length": "700",
     }
 
     for k, v in resp.request.headers.items():


### PR DESCRIPTION
It is immediately useful to me to know how an action was triggered, whether it was a manual dispatch, on a PR, or push to the branch.

This adds the supported `event` tag, and a test to verify functionality.